### PR TITLE
Bug fixes

### DIFF
--- a/lib/search/stat_facet.rb
+++ b/lib/search/stat_facet.rb
@@ -41,8 +41,8 @@ module Sunspot
           end if @sort
           return rows.empty? ? [] : rows[0..@options[:limit]]
         rescue Exception => e
-          return []
           puts "Error: #{e}"
+          return []
         end
       end
     end

--- a/lib/search/stat_search.rb
+++ b/lib/search/stat_search.rb
@@ -40,10 +40,12 @@ module Sunspot
 
       def stat_response #:nodoc:
         @solr_result['stats']["stats_fields"].each_pair do |k, value|
-          value["facets"].each_pair do |k1, value1|
-            value1.each_pair do |k2, value2|
-              if @solr_result['stats']['stats_fields'][k]['facets'][k1][k2]['mean'].to_s == 'NaN'
-                @solr_result['stats']['stats_fields'][k]['facets'][k1][k2]['mean'] = 0.0
+          if value && value.key?("facets")
+            value["facets"].each_pair do |k1, value1|
+              value1.each_pair do |k2, value2|
+                if @solr_result['stats']['stats_fields'][k]['facets'][k1][k2]['mean'].to_s == 'NaN'
+                  @solr_result['stats']['stats_fields'][k]['facets'][k1][k2]['mean'] = 0.0
+                end
               end
             end
           end


### PR DESCRIPTION
When an error occurs  in StatFacet, it would fail silently without printing to the console because the puts was after the return.

Also, if the search did not contain facets, the call to  `value["facets"].collect` in StatSearch would fail (silently, because of the above bug), and just return an empty array.
